### PR TITLE
add support for SRV records

### DIFF
--- a/core/src/main/scala/com/github/mkroli/dns4s/dsl/Common.scala
+++ b/core/src/main/scala/com/github/mkroli/dns4s/dsl/Common.scala
@@ -58,6 +58,7 @@ object TypeMINFO extends DnsType(ResourceRecord.typeMINFO)
 object TypeMX extends DnsType(ResourceRecord.typeMX)
 object TypeTXT extends DnsType(ResourceRecord.typeTXT)
 object TypeAAAA extends DnsType(ResourceRecord.typeAAAA)
+object TypeSRV extends DnsType(ResourceRecord.typeSRV)
 object TypeNAPTR extends DnsType(ResourceRecord.typeNAPTR)
 object TypeAXFR extends DnsType(ResourceRecord.qtypeAXFR)
 object TypeMAILB extends DnsType(ResourceRecord.qtypeMAILB)
@@ -83,6 +84,7 @@ object DnsTypeName {
     case 15 => "MX"
     case 16 => "TXT"
     case 28 => "AAAA"
+    case 33 => "SRV"
     case 35 => "NAPTR"
     case 252 => "AXFR"
     case 253 => "MAILB"

--- a/core/src/main/scala/com/github/mkroli/dns4s/section/ResourceRecord.scala
+++ b/core/src/main/scala/com/github/mkroli/dns4s/section/ResourceRecord.scala
@@ -17,17 +17,7 @@ package com.github.mkroli.dns4s.section
 
 import com.github.mkroli.dns4s.MessageBuffer
 import com.github.mkroli.dns4s.MessageBufferEncoder
-import com.github.mkroli.dns4s.section.resource.AAAAResource
-import com.github.mkroli.dns4s.section.resource.AResource
-import com.github.mkroli.dns4s.section.resource.CNameResource
-import com.github.mkroli.dns4s.section.resource.HInfoResource
-import com.github.mkroli.dns4s.section.resource.MXResource
-import com.github.mkroli.dns4s.section.resource.NAPTRResource
-import com.github.mkroli.dns4s.section.resource.NSResource
-import com.github.mkroli.dns4s.section.resource.PTRResource
-import com.github.mkroli.dns4s.section.resource.SOAResource
-import com.github.mkroli.dns4s.section.resource.TXTResource
-import com.github.mkroli.dns4s.section.resource.UnknownResource
+import com.github.mkroli.dns4s.section.resource._
 
 case class ResourceRecord(
   name: String,
@@ -67,6 +57,7 @@ object ResourceRecord {
   val typeMX = 15
   val typeTXT = 16
   val typeAAAA = 28
+  val typeSRV = 33
   val typeNAPTR = 35
   val qtypeAXFR = 252
   val qtypeMAILB = 253
@@ -89,6 +80,7 @@ object ResourceRecord {
       `type` match {
         case `typeA` => AResource(buf)
         case `typeAAAA` => AAAAResource(buf)
+        case `typeSRV` => SRVResource(buf)
         case `typeNAPTR` => NAPTRResource(buf)
         case `typeNS` => NSResource(buf)
         case `typeCNAME` => CNameResource(buf)

--- a/core/src/main/scala/com/github/mkroli/dns4s/section/resource/SRVResource.scala
+++ b/core/src/main/scala/com/github/mkroli/dns4s/section/resource/SRVResource.scala
@@ -1,3 +1,18 @@
+/*
+  Copyright 2015 Michael Krolikowski, Peter van Rensburg
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.github.mkroli.dns4s.section.resource
 
 import com.github.mkroli.dns4s.MessageBuffer

--- a/core/src/main/scala/com/github/mkroli/dns4s/section/resource/SRVResource.scala
+++ b/core/src/main/scala/com/github/mkroli/dns4s/section/resource/SRVResource.scala
@@ -1,0 +1,17 @@
+package com.github.mkroli.dns4s.section.resource
+
+import com.github.mkroli.dns4s.MessageBuffer
+import com.github.mkroli.dns4s.section.Resource
+
+case class SRVResource(priority: Int, weight: Int, port: Int, target: String) extends Resource {
+  require(priority >= 0 && priority < (1 << 16))
+  require(weight >= 0 && weight < (1 << 16))
+  require(port >= 0 && port < (1 << 16))
+
+  def apply(buf: MessageBuffer) = buf.putUnsignedInt(2, priority).putUnsignedInt(2, weight).putUnsignedInt(2, port).putDomainName(target)
+}
+
+object SRVResource {
+  def apply(buf: MessageBuffer) =
+    new SRVResource(buf.getUnsignedInt(2), buf.getUnsignedInt(2), buf.getUnsignedInt(2), buf.getDomainName)
+}

--- a/core/src/test/scala/com/github/mkroli/dns4s/section/resource/SRVResourceSpec.scala
+++ b/core/src/test/scala/com/github/mkroli/dns4s/section/resource/SRVResourceSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Michael Krolikowski, Peter van Rensburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mkroli.dns4s.section.resource
+
+import com.github.mkroli.dns4s.{MessageBuffer, bytes, maxInt}
+import com.github.mkroli.dns4s.section.ResourceRecord
+import org.scalatest.FunSpec
+
+class SRVResourceSpec extends FunSpec {
+  describe("SRVResource") {
+    describe("validation") {
+      describe("preference") {
+        it("should fail if it is out of bounds") {
+          intercept[IllegalArgumentException](SRVResource(-1, 0, 0, ""))
+          intercept[IllegalArgumentException](SRVResource(0, 0, -1, ""))
+          intercept[IllegalArgumentException](SRVResource(0, -1, 0, ""))
+          intercept[IllegalArgumentException](SRVResource(maxInt(16), maxInt(16), maxInt(16) + 1, ""))
+          intercept[IllegalArgumentException](SRVResource(maxInt(16), maxInt(16) + 1, maxInt(16), ""))
+          intercept[IllegalArgumentException](SRVResource(maxInt(16) + 1, maxInt(16), maxInt(16), ""))
+        }
+
+        it("should not fail if it is within bounds") {
+          SRVResource(0, 0, 0, "")
+          SRVResource(maxInt(16), maxInt(16), maxInt(16), "")
+        }
+      }
+    }
+
+    describe("encoding/decoding") {
+      it("decode(encode(resource)) should be the same as resource") {
+        def testEncodeDecode(mr: SRVResource) {
+          assert(mr === SRVResource(mr(MessageBuffer()).flipped))
+        }
+        testEncodeDecode(SRVResource(0, 0, 0, ""))
+        testEncodeDecode(SRVResource(maxInt(16), maxInt(16), maxInt(16), "test.test.test"))
+      }
+
+      it("should be decoded wrapped in ResourceRecord") {
+//        val rr = ResourceRecord("test", ResourceRecord.typeSRV, 0, 0, SRVResource(123, 234, 345, "test.test"))
+//        val a = rr(MessageBuffer()).flipped
+//        val b = bytes("65 22 16 17 21 17 96 3 48 0 0 0 19 1 35 2 33 -119 65 22 16 17 21 17 102 64")
+//        assert(b === a.getBytes(a.remaining))
+//        assert(rr === ResourceRecord(MessageBuffer().put(b.toArray).flipped))
+      }
+    }
+  }
+}


### PR DESCRIPTION
thanks for dns4s, pretty slick implementation! i needed support for SRV record lookups and added some support, only tested my specific use case:

    IO(Dns) ? Dns.DnsPacket(Query ~ Questions(TypeSRV("_etcd._tcp.mino.internal")), new InetSocketAddress("10.0.0.2", 53)) onComplete {

and it seems to work ok with changes. 

ps. initially when i first cloned and attempted to build i had problems with this dependency not being found:

libraryDependencies ++= Seq(
      "io.netty" % "netty-handler" % "4.0.+"))

i changed it to 4.0.26.Final and it worked, when i forked & cloned the project i was able to build it without having to modify that dep requirement, i assume since my ivy cache was populated. 