### PR TITLE
introduce edns client subnet option (WIP)

### DIFF
--- a/core/src/main/scala/com/github/mkroli/dns4s/section/resource/AResource.scala
+++ b/core/src/main/scala/com/github/mkroli/dns4s/section/resource/AResource.scala
@@ -22,7 +22,7 @@ import com.github.mkroli.dns4s.MessageBuffer
 import com.github.mkroli.dns4s.section.Resource
 
 case class AResource(address: Inet4Address) extends Resource {
-  def apply(buf: MessageBuffer) = buf.put(address.getAddress())
+  def apply(buf: MessageBuffer): MessageBuffer = buf.put(address.getAddress())
 }
 
 object AResource {

--- a/core/src/test/scala/com/github/mkroli/dns4s/dsl/CommonSpec.scala
+++ b/core/src/test/scala/com/github/mkroli/dns4s/dsl/CommonSpec.scala
@@ -24,7 +24,7 @@ class CommonSpec extends FunSpec {
   describe("Common") {
     it("should be possible to combine MessageModifierS") {
       val txt = Answers(TXTRecord("test"))
-      val ext = EDNS()
+      val ext = EDNS(1, 1, 1, 24, 0, "127.0.0.1")
       val mm = txt ~ ext
       Response ~ mm match {
         case Response(Answers(TXTRecord(TXTResource(Seq("test"))) :: Nil) ~ EDNS(_)) =>

--- a/core/src/test/scala/com/github/mkroli/dns4s/dsl/ResourceRecordSpec.scala
+++ b/core/src/test/scala/com/github/mkroli/dns4s/dsl/ResourceRecordSpec.scala
@@ -77,16 +77,16 @@ class ResourceRecordSpec extends FunSpec {
     }
 
     it("should be possible to set edns") {
-      Response ~ EDNS() match {
-        case Response(EDNS(4096)) =>
+      Response ~ EDNS(1, 1, 1, 24, 0, "127.0.0.1") match {
+        case Response(EDNS(_)) =>
       }
 
-      Response ~ EDNS(123) match {
-        case Response(_) ~ EDNS(123) =>
+      Response ~ EDNS(1, 1, 1, 24, 0, "127.0.0.1") match {
+        case Response(_) ~ EDNS(_) =>
       }
 
-      Response ~ EDNS() match {
-        case Response(Additional(OPTRecord(OPTResource()) ~ RRClass(4096) :: Nil)) =>
+      Response ~ EDNS(1, 1, 1, 24, 0, "127.0.0.1") match {
+        case Response(Additional(OPTRecord(OPTResource(1, 1, 1, 24, 0, "127.0.0.1")) ~ RRClass(4096) :: Nil)) =>
       }
     }
 
@@ -143,8 +143,8 @@ class ResourceRecordSpec extends FunSpec {
     }
 
     it("should be possible to use OPTRecord") {
-      Response ~ Additional(OPTRecord()) match {
-        case Response(Additional(OPTRecord(OPTResource()) :: Nil)) =>
+      Response ~ Additional(OPTRecord(1, 1, 1, 24, 0, "127.0.0.1")) match {
+        case Response(Additional(OPTRecord(OPTResource(1, 1, 1, 24, 0, "127.0.0.1")) :: Nil)) =>
       }
     }
 

--- a/core/src/test/scala/com/github/mkroli/dns4s/section/resource/OPTResourceSpec.scala
+++ b/core/src/test/scala/com/github/mkroli/dns4s/section/resource/OPTResourceSpec.scala
@@ -28,14 +28,14 @@ class OPTResourceSpec extends FunSpec with PropertyChecks {
     describe("encoding/decoding") {
       it("decode(encode(resource)) should be the same as resource") {
         forAll(bytesGenerator()) { bytes =>
-          val r = OPTResource()
-          val encoded = r(MessageBuffer()).put(bytes).flipped()
+          val r: OPTResource = OPTResource(1, 1, 1, 24, 0, "127.0.0.1")
+          val encoded = r.apply(MessageBuffer()).put(bytes).flipped()
           assert(r === OPTResource(encoded, bytes.length))
         }
       }
 
       it("should be decoded wrapped in ResourceRecord") {
-        val rr = ResourceRecord("test", ResourceRecord.typeOPT, 0, 0, OPTResource())
+        val rr = ResourceRecord("test", ResourceRecord.typeOPT, 0, 0, OPTResource(1, 1, 1, 24, 0, "127.0.0.1"))
         val a = rr(MessageBuffer()).flipped()
         val b = bytes("04 74 65 73 74 00  0029 0000 00000000 0000")
         assert(b === a.getBytes(a.remaining))


### PR DESCRIPTION
- the current EDNS option was not using, it's useless
- implement EDNS to include client ip option which is useful, described
  in this ietf draft by Google
https://tools.ietf.org/html/draft-vandergaast-edns-client-ip-01

@mkroli please take a look, thank 